### PR TITLE
Change reload_modules to trigger only on state changes (#39015)

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -88,7 +88,8 @@ STATE_RUNTIME_KEYWORDS = frozenset([
     'prereq',
     'prereq_in',
     'prerequired',
-    'reload_modules',
+    '
+    ',
     'reload_grains',
     'reload_pillar',
     'fire_event',
@@ -937,12 +938,12 @@ class State(object):
             self.opts['pillar'] = self._gather_pillar()
             _reload_modules = True
 
+        if not ret['changes']:
+            return
+
         if data.get('reload_modules', False) or _reload_modules:
             # User explicitly requests a reload
             self.module_refresh()
-            return
-
-        if not ret['changes']:
             return
 
         if data['state'] == 'file':


### PR DESCRIPTION
### What does this PR do?
It changes state behaviour while used with
```
reload_modules: True
```

* Helps with performance
* reload_modules 99.9% of the time used by Salt users along with pip.installed, pkg.installed or cmd.run which remain compatible.
* Creates minor incompatibility if used with a logically-incomplete state that does not properly report changes.

It's somehow related to another performance bug #39011 and makes it affect my execution time a lot less :)

Please merge forward to 2016.11 if accepted.

### What issues does this PR fix or reference?

Fixes #39015, related to #39011

### Previous Behavior
Remove this section if not relevant

reload all modules even if the state didn't report any changes

### New Behavior
Remove this section if not relevant

reload the modules only in case the state reported some changes

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
